### PR TITLE
[브루니] step-6 기물 이동 구현

### DIFF
--- a/src/main/java/chess/board/Board.java
+++ b/src/main/java/chess/board/Board.java
@@ -135,4 +135,10 @@ public class Board {
 		placePiece(Dummy.of(), from);
 		placePiece(source, to);
 	}
+
+	public void checkTurn(final Color turn, final Position from) {
+		if (turn != board.get(from.getX()).getPiece(from.getY()).getColor()) {
+			throw new BusinessException(ErrorCode.INVALID_TURN);
+		}
+	}
 }

--- a/src/main/java/chess/board/Board.java
+++ b/src/main/java/chess/board/Board.java
@@ -126,7 +126,7 @@ public class Board {
 		Piece target = findPiece(to);
 
 		source.verifyMovePosition(to, target);
-		Set<Position> positions = source.movablePositions(from);
+		Set<Position> positions = source.movablePositions(from, target);
 
 		if (!positions.contains(to)) {
 			throw new BusinessException(ErrorCode.INVALID_POSITION);

--- a/src/main/java/chess/board/Board.java
+++ b/src/main/java/chess/board/Board.java
@@ -126,7 +126,7 @@ public class Board {
 		Piece target = findPiece(to);
 
 		source.verifyMovePosition(to, target);
-		Set<Position> positions = source.movablePositions(from, target);
+		Set<Position> positions = source.movablePositions(from, target, board);
 
 		if (!positions.contains(to)) {
 			throw new BusinessException(ErrorCode.INVALID_POSITION);

--- a/src/main/java/chess/exception/ErrorCode.java
+++ b/src/main/java/chess/exception/ErrorCode.java
@@ -3,11 +3,16 @@ package chess.exception;
 public enum ErrorCode {
 
 	NO_MATCH_COLOR("유효하지 않은 색깔"),
-	INVALID_POSITION("유효하지 않은 위치정보");
+	INVALID_POSITION("유효하지 않은 위치정보"),
+	INVALID_TURN("현재 사용자의 턴이 아님");
 
 	private final String description;
 
 	ErrorCode(String description) {
 		this.description = description;
+	}
+
+	public String getDescription() {
+		return description;
 	}
 }

--- a/src/main/java/chess/game/ChessGame.java
+++ b/src/main/java/chess/game/ChessGame.java
@@ -2,6 +2,8 @@ package chess.game;
 
 import chess.board.Board;
 import chess.board.Position;
+import chess.exception.BusinessException;
+import chess.pieces.color.Color;
 import chess.view.ChessView;
 import chess.view.InputUtils;
 
@@ -14,11 +16,17 @@ public class ChessGame {
 	private final Board board = new Board();
 	private final ChessView chessView = new ChessView();
 
+	private Color turn = Color.WHITE;
+
 	public ChessGame() {
 		board.initialize();
 	}
 
 	public void run() {
+		System.out.println("-----체스 게임-----");
+		System.out.println("게임 시작 커맨드 : start");
+		System.out.println("기물 이동 커맨드 : move src dst (ex. move a1 a3)");
+		System.out.println("게임 종료 커맨드 : end");
 		while (true) {
 			String command = InputUtils.getCommand();
 
@@ -35,13 +43,15 @@ public class ChessGame {
 				} else {
 					System.out.println(command + " 명령어는 지원하지 않습니다.");
 				}
-			} catch (Exception e) {
-				System.out.println(e.getMessage());
+			} catch (BusinessException e) {
+				System.out.println(e.getErrorCode().getDescription());
 			}
 		}
 	}
 
 	private void move(final String from, final String to) {
+		board.checkTurn(turn, new Position(from));
 		board.move(new Position(from), new Position(to));
+		turn = Color.changeTurn(turn);
 	}
 }

--- a/src/main/java/chess/pieces/Bishop.java
+++ b/src/main/java/chess/pieces/Bishop.java
@@ -1,11 +1,13 @@
 package chess.pieces;
 
 import chess.board.Position;
+import chess.board.Rank;
 import chess.pieces.color.Color;
 import chess.pieces.direction.Direction;
 import chess.pieces.type.Type;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -20,11 +22,11 @@ public class Bishop extends Piece {
 	}
 
 	@Override
-	public Set<Position> movablePositions(final Position from, final Piece target) {
+	public Set<Position> movablePositions(final Position from, final Piece target, final List<Rank> board) {
 		Set<Position> positions = new HashSet<>();
 
 		for (Direction direction : Direction.diagonalDirection()) {
-			addMovablePositions(positions, from, direction);
+			addMovablePositions(positions, from, direction, board);
 		}
 
 		return positions.stream().collect(Collectors.toUnmodifiableSet());

--- a/src/main/java/chess/pieces/Bishop.java
+++ b/src/main/java/chess/pieces/Bishop.java
@@ -20,7 +20,7 @@ public class Bishop extends Piece {
 	}
 
 	@Override
-	public Set<Position> movablePositions(Position from) {
+	public Set<Position> movablePositions(final Position from, final Piece target) {
 		Set<Position> positions = new HashSet<>();
 
 		for (Direction direction : Direction.diagonalDirection()) {

--- a/src/main/java/chess/pieces/King.java
+++ b/src/main/java/chess/pieces/King.java
@@ -1,11 +1,13 @@
 package chess.pieces;
 
 import chess.board.Position;
+import chess.board.Rank;
 import chess.pieces.color.Color;
 import chess.pieces.direction.Direction;
 import chess.pieces.type.Type;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -20,7 +22,7 @@ public class King extends Piece {
 	}
 
 	@Override
-	public Set<Position> movablePositions(final Position from, final Piece target) {
+	public Set<Position> movablePositions(final Position from, final Piece target, final List<Rank> board) {
 		Set<Position> movablePosition = new HashSet<>();
 
 		for (Direction direction : Direction.everyDirection()) {

--- a/src/main/java/chess/pieces/King.java
+++ b/src/main/java/chess/pieces/King.java
@@ -20,7 +20,7 @@ public class King extends Piece {
 	}
 
 	@Override
-	public Set<Position> movablePositions(final Position from) {
+	public Set<Position> movablePositions(final Position from, final Piece target) {
 		Set<Position> movablePosition = new HashSet<>();
 
 		for (Direction direction : Direction.everyDirection()) {

--- a/src/main/java/chess/pieces/Knight.java
+++ b/src/main/java/chess/pieces/Knight.java
@@ -1,11 +1,13 @@
 package chess.pieces;
 
 import chess.board.Position;
+import chess.board.Rank;
 import chess.pieces.color.Color;
 import chess.pieces.direction.Direction;
 import chess.pieces.type.Type;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -20,7 +22,7 @@ public class Knight extends Piece {
 	}
 
 	@Override
-	public Set<Position> movablePositions(final Position from, final Piece target) {
+	public Set<Position> movablePositions(final Position from, final Piece target, final List<Rank> board) {
 		Set<Position> positions = new HashSet<>();
 
 		for (Direction direction : Direction.knightDirection()) {

--- a/src/main/java/chess/pieces/Knight.java
+++ b/src/main/java/chess/pieces/Knight.java
@@ -20,7 +20,7 @@ public class Knight extends Piece {
 	}
 
 	@Override
-	public Set<Position> movablePositions(final Position from) {
+	public Set<Position> movablePositions(final Position from, final Piece target) {
 		Set<Position> positions = new HashSet<>();
 
 		for (Direction direction : Direction.knightDirection()) {

--- a/src/main/java/chess/pieces/Pawn.java
+++ b/src/main/java/chess/pieces/Pawn.java
@@ -22,10 +22,10 @@ public class Pawn extends Piece {
 	}
 
 	@Override
-	public Set<Position> movablePositions(final Position from) {
+	public Set<Position> movablePositions(final Position from, final Piece target) {
 		Set<Position> positions = new HashSet<>();
-
-		for (Direction direction : Direction.pawnDirection(getColor(), isInitialMove)) {
+		boolean isAttack = target.getColor() != getColor() && !(target instanceof Dummy);
+		for (Direction direction : Direction.pawnDirection(getColor(), isInitialMove, isAttack)) {
 			positions.add(new Position(from.getX() + direction.getXDegree(), from.getY() + direction.getYDegree()));
 		}
 		if (isInitialMove) {

--- a/src/main/java/chess/pieces/Pawn.java
+++ b/src/main/java/chess/pieces/Pawn.java
@@ -1,11 +1,13 @@
 package chess.pieces;
 
 import chess.board.Position;
+import chess.board.Rank;
 import chess.pieces.color.Color;
 import chess.pieces.direction.Direction;
 import chess.pieces.type.Type;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -22,7 +24,7 @@ public class Pawn extends Piece {
 	}
 
 	@Override
-	public Set<Position> movablePositions(final Position from, final Piece target) {
+	public Set<Position> movablePositions(final Position from, final Piece target, final List<Rank> board) {
 		Set<Position> positions = new HashSet<>();
 		boolean isAttack = target.getColor() != getColor() && !(target instanceof Dummy);
 		for (Direction direction : Direction.pawnDirection(getColor(), isInitialMove, isAttack)) {

--- a/src/main/java/chess/pieces/Pawn.java
+++ b/src/main/java/chess/pieces/Pawn.java
@@ -11,6 +11,8 @@ import java.util.stream.Collectors;
 
 public class Pawn extends Piece {
 
+	private boolean isInitialMove = true;
+
 	private Pawn(final Color color) {
 		super(color, Type.PAWN);
 	}
@@ -23,8 +25,11 @@ public class Pawn extends Piece {
 	public Set<Position> movablePositions(final Position from) {
 		Set<Position> positions = new HashSet<>();
 
-		for (Direction direction : Direction.pawnDirection(getColor())) {
+		for (Direction direction : Direction.pawnDirection(getColor(), isInitialMove)) {
 			positions.add(new Position(from.getX() + direction.getXDegree(), from.getY() + direction.getYDegree()));
+		}
+		if (isInitialMove) {
+			isInitialMove = false;
 		}
 
 		return positions.stream().collect(Collectors.toUnmodifiableSet());

--- a/src/main/java/chess/pieces/Piece.java
+++ b/src/main/java/chess/pieces/Piece.java
@@ -51,7 +51,7 @@ public abstract class Piece {
 		}
 	}
 
-	public Set<Position> movablePositions(Position from) {
+	public Set<Position> movablePositions(Position from, Piece target) {
 		return Set.of();
 	}
 

--- a/src/main/java/chess/pieces/Piece.java
+++ b/src/main/java/chess/pieces/Piece.java
@@ -1,12 +1,14 @@
 package chess.pieces;
 
 import chess.board.Position;
+import chess.board.Rank;
 import chess.exception.BusinessException;
 import chess.exception.ErrorCode;
 import chess.pieces.color.Color;
 import chess.pieces.direction.Direction;
 import chess.pieces.type.Type;
 
+import java.util.List;
 import java.util.Set;
 
 public abstract class Piece {
@@ -51,11 +53,11 @@ public abstract class Piece {
 		}
 	}
 
-	public Set<Position> movablePositions(Position from, Piece target) {
+	public Set<Position> movablePositions(Position from, Piece target, List<Rank> board) {
 		return Set.of();
 	}
 
-	protected void addMovablePositions(Set<Position> positions, Position current, Direction direction) {
+	protected void addMovablePositions(Set<Position> positions, Position current, Direction direction, List<Rank> board) {
 		int x = current.getX();
 		int y = current.getY();
 
@@ -63,7 +65,10 @@ public abstract class Piece {
 			int nextX = x + direction.getXDegree() * i;
 			int nextY = y + direction.getYDegree() * i;
 			if (!isValidPosition(nextX, nextY)) {
-				continue;
+				break;
+			}
+			if (!(board.get(nextX).getPiece(nextY) instanceof Dummy)) {
+				break;
 			}
 			positions.add(new Position(nextX, nextY));
 		}

--- a/src/main/java/chess/pieces/Queen.java
+++ b/src/main/java/chess/pieces/Queen.java
@@ -1,11 +1,13 @@
 package chess.pieces;
 
 import chess.board.Position;
+import chess.board.Rank;
 import chess.pieces.color.Color;
 import chess.pieces.direction.Direction;
 import chess.pieces.type.Type;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -20,11 +22,11 @@ public class Queen extends Piece {
 	}
 
 	@Override
-	public Set<Position> movablePositions(final Position from, final Piece target) {
+	public Set<Position> movablePositions(final Position from, final Piece target, final List<Rank> board) {
 		Set<Position> positions = new HashSet<>();
 
 		for (Direction direction : Direction.everyDirection()) {
-			addMovablePositions(positions, from, direction);
+			addMovablePositions(positions, from, direction, board);
 		}
 
 		return positions.stream().collect(Collectors.toUnmodifiableSet());

--- a/src/main/java/chess/pieces/Queen.java
+++ b/src/main/java/chess/pieces/Queen.java
@@ -20,7 +20,7 @@ public class Queen extends Piece {
 	}
 
 	@Override
-	public Set<Position> movablePositions(Position from) {
+	public Set<Position> movablePositions(final Position from, final Piece target) {
 		Set<Position> positions = new HashSet<>();
 
 		for (Direction direction : Direction.everyDirection()) {

--- a/src/main/java/chess/pieces/Rook.java
+++ b/src/main/java/chess/pieces/Rook.java
@@ -20,7 +20,7 @@ public class Rook extends Piece {
 	}
 
 	@Override
-	public Set<Position> movablePositions(final Position from) {
+	public Set<Position> movablePositions(final Position from, final Piece target) {
 		Set<Position> positions = new HashSet<>();
 
 		for (Direction direction : Direction.linearDirection()) {

--- a/src/main/java/chess/pieces/Rook.java
+++ b/src/main/java/chess/pieces/Rook.java
@@ -1,11 +1,13 @@
 package chess.pieces;
 
 import chess.board.Position;
+import chess.board.Rank;
 import chess.pieces.color.Color;
 import chess.pieces.direction.Direction;
 import chess.pieces.type.Type;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -20,11 +22,11 @@ public class Rook extends Piece {
 	}
 
 	@Override
-	public Set<Position> movablePositions(final Position from, final Piece target) {
+	public Set<Position> movablePositions(final Position from, final Piece target, final List<Rank> board) {
 		Set<Position> positions = new HashSet<>();
 
 		for (Direction direction : Direction.linearDirection()) {
-			addMovablePositions(positions, from, direction);
+			addMovablePositions(positions, from, direction, board);
 		}
 
 		return positions.stream().collect(Collectors.toUnmodifiableSet());

--- a/src/main/java/chess/pieces/color/Color.java
+++ b/src/main/java/chess/pieces/color/Color.java
@@ -25,4 +25,11 @@ public enum Color {
 				.findFirst()
 				.orElseThrow(() -> new BusinessException(ErrorCode.NO_MATCH_COLOR));
 	}
+
+	public static Color changeTurn(final Color color) {
+		if (color == WHITE) {
+			return BLACK;
+		}
+		return WHITE;
+	}
 }

--- a/src/main/java/chess/pieces/direction/Direction.java
+++ b/src/main/java/chess/pieces/direction/Direction.java
@@ -59,24 +59,38 @@ public enum Direction {
 		return Arrays.asList(NNE, NNW, SSE, SSW, EEN, EES, WWN, WWS);
 	}
 
-	public static List<Direction> pawnDirection(Color color, boolean isInitialMove) {
+	public static List<Direction> pawnDirection(Color color, boolean isInitialMove, boolean isAttack) {
 		if (color == Color.BLACK) {
+			if (isAttack) {
+				return blackPawnAttackDirection();
+			}
 			return blackPawnDirection(isInitialMove);
+		}
+		if (isAttack) {
+			return whitePawnAttackDirection();
 		}
 		return whitePawnDirection(isInitialMove);
 	}
 
+	private static List<Direction> whitePawnAttackDirection() {
+		return Arrays.asList(NORTH_EAST, NORTH_WEST);
+	}
+
+	private static List<Direction> blackPawnAttackDirection() {
+		return Arrays.asList(SOUTH_EAST, SOUTH_WEST);
+	}
+
 	private static List<Direction> whitePawnDirection(boolean isInitialMove) {
 		if (isInitialMove) {
-			return Arrays.asList(NORTH, NN, NORTH_EAST, NORTH_WEST);
+			return Arrays.asList(NORTH, NN);
 		}
-		return Arrays.asList(NORTH, NORTH_EAST, NORTH_WEST);
+		return Arrays.asList(NORTH);
 	}
 
 	private static List<Direction> blackPawnDirection(boolean isInitialMove) {
 		if (isInitialMove) {
-			return Arrays.asList(SOUTH, SS, SOUTH_EAST, SOUTH_WEST);
+			return Arrays.asList(SOUTH, SS);
 		}
-		return Arrays.asList(SOUTH, SOUTH_EAST, SOUTH_WEST);
+		return Arrays.asList(SOUTH);
 	}
 }

--- a/src/main/java/chess/pieces/direction/Direction.java
+++ b/src/main/java/chess/pieces/direction/Direction.java
@@ -16,6 +16,8 @@ public enum Direction {
 	WEST(0, -1),
 	NORTH_WEST(-1, -1),
 
+	NN(-2, 0),
+	SS(2, 0),
 	NNE(-2, 1),
 	NNW(-2, -1),
 	SSE(2, 1),
@@ -57,18 +59,24 @@ public enum Direction {
 		return Arrays.asList(NNE, NNW, SSE, SSW, EEN, EES, WWN, WWS);
 	}
 
-	public static List<Direction> pawnDirection(Color color) {
+	public static List<Direction> pawnDirection(Color color, boolean isInitialMove) {
 		if (color == Color.BLACK) {
-			return blackPawnDirection();
+			return blackPawnDirection(isInitialMove);
 		}
-		return whitePawnDirection();
+		return whitePawnDirection(isInitialMove);
 	}
 
-	private static List<Direction> whitePawnDirection() {
+	private static List<Direction> whitePawnDirection(boolean isInitialMove) {
+		if (isInitialMove) {
+			return Arrays.asList(NORTH, NN, NORTH_EAST, NORTH_WEST);
+		}
 		return Arrays.asList(NORTH, NORTH_EAST, NORTH_WEST);
 	}
 
-	private static List<Direction> blackPawnDirection() {
+	private static List<Direction> blackPawnDirection(boolean isInitialMove) {
+		if (isInitialMove) {
+			return Arrays.asList(SOUTH, SS, SOUTH_EAST, SOUTH_WEST);
+		}
 		return Arrays.asList(SOUTH, SOUTH_EAST, SOUTH_WEST);
 	}
 }

--- a/src/main/java/chess/view/InputUtils.java
+++ b/src/main/java/chess/view/InputUtils.java
@@ -10,6 +10,7 @@ public final class InputUtils {
 	}
 
 	public static String getCommand() {
+		System.out.print("명령어를 입력해주세요 : ");
 		return scanner.nextLine();
 	}
 }

--- a/src/test/java/chess/board/BoardTest.java
+++ b/src/test/java/chess/board/BoardTest.java
@@ -16,8 +16,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 
 class BoardTest {
 
@@ -138,5 +137,31 @@ class BoardTest {
 		sut.placePiece(Pawn.of(Color.WHITE), new Position("g2"));
 		sut.placePiece(Rook.of(Color.WHITE), new Position("e1"));
 		sut.placePiece(King.of(Color.WHITE), new Position("f1"));
+	}
+
+	@DisplayName("턴이 유효한지 확인할 때 현재 턴과 움직이려는 위치 정보가 주어지면 확인에 성공한다.")
+	@Test
+	void givenCurrentTurnAndPosition_whenCheckTurn_thenSuccessCheck() {
+		// given
+		Color currentTurn = Color.WHITE;
+		Position position = new Position("a2");
+
+		// when & then
+		assertThatCode(() -> sut.checkTurn(currentTurn, position))
+				.doesNotThrowAnyException();
+	}
+
+	@DisplayName("턴이 유효한지 확인할 때 현재 턴과 움직이려는 위치 정보가 일치하지 않으면 예외를 던진다.")
+	@Test
+	void givenCurrentTurnAndInvalidPosition_whenCheckTurn_thenThrowsException() {
+		// given
+		Color currentTurn = Color.BLACK;
+		Position position = new Position("a2");
+
+		// when & then
+		assertThatThrownBy(() -> sut.checkTurn(currentTurn, position))
+				.isInstanceOf(BusinessException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.INVALID_TURN);
 	}
 }

--- a/src/test/java/chess/pieces/BishopTest.java
+++ b/src/test/java/chess/pieces/BishopTest.java
@@ -1,5 +1,6 @@
 package chess.pieces;
 
+import chess.board.Board;
 import chess.board.Position;
 import chess.pieces.color.Color;
 import org.junit.jupiter.api.DisplayName;
@@ -15,15 +16,17 @@ class BishopTest {
 	@Test
 	void givenBishop_whenFindMovablePositions_thenReturnsMovablePositions() {
 		// given
+		Board board = new Board();
+		board.initialize();
 		Bishop bishop = Bishop.of(Color.BLACK);
 
-		Set<Position> positions = bishop.movablePositions(new Position("c5"), Dummy.of());
+		Set<Position> positions = bishop.movablePositions(new Position("c5"), Dummy.of(), board.getBoard());
 
 		assertThat(positions).containsExactlyInAnyOrder(
-				new Position("b6"), new Position("a7"),
-				new Position("d6"), new Position("e7"), new Position("f8"),
+				new Position("b6"),
+				new Position("d6"),
 				new Position("b4"), new Position("a3"),
-				new Position("d4"), new Position("e3"), new Position("f2"), new Position("g1")
+				new Position("d4"), new Position("e3")
 		);
 	}
 }

--- a/src/test/java/chess/pieces/BishopTest.java
+++ b/src/test/java/chess/pieces/BishopTest.java
@@ -17,7 +17,7 @@ class BishopTest {
 		// given
 		Bishop bishop = Bishop.of(Color.BLACK);
 
-		Set<Position> positions = bishop.movablePositions(new Position("c5"));
+		Set<Position> positions = bishop.movablePositions(new Position("c5"), Dummy.of());
 
 		assertThat(positions).containsExactlyInAnyOrder(
 				new Position("b6"), new Position("a7"),

--- a/src/test/java/chess/pieces/KingTest.java
+++ b/src/test/java/chess/pieces/KingTest.java
@@ -1,5 +1,6 @@
 package chess.pieces;
 
+import chess.board.Board;
 import chess.board.Position;
 import chess.pieces.color.Color;
 import org.junit.jupiter.api.DisplayName;
@@ -15,9 +16,11 @@ class KingTest {
 	@Test
 	void givenKing_whenFindMovablePositions_thenReturnsMovablePositions() {
 		// given
+		Board board = new Board();
+		board.initialize();
 		King king = King.of(Color.BLACK);
 
-		Set<Position> positions = king.movablePositions(new Position("c5"), Dummy.of());
+		Set<Position> positions = king.movablePositions(new Position("c5"), Dummy.of(), board.getBoard());
 
 		assertThat(positions).containsExactlyInAnyOrder(
 				new Position("c6"), // 상

--- a/src/test/java/chess/pieces/KingTest.java
+++ b/src/test/java/chess/pieces/KingTest.java
@@ -17,7 +17,7 @@ class KingTest {
 		// given
 		King king = King.of(Color.BLACK);
 
-		Set<Position> positions = king.movablePositions(new Position("c5"));
+		Set<Position> positions = king.movablePositions(new Position("c5"), Dummy.of());
 
 		assertThat(positions).containsExactlyInAnyOrder(
 				new Position("c6"), // 상

--- a/src/test/java/chess/pieces/KnightTest.java
+++ b/src/test/java/chess/pieces/KnightTest.java
@@ -17,7 +17,7 @@ class KnightTest {
 		// given
 		Knight knight = Knight.of(Color.BLACK);
 
-		Set<Position> positions = knight.movablePositions(new Position("c5"));
+		Set<Position> positions = knight.movablePositions(new Position("c5"), Dummy.of());
 
 		assertThat(positions).containsExactlyInAnyOrder(
 				new Position("b7"), new Position("a6"),

--- a/src/test/java/chess/pieces/KnightTest.java
+++ b/src/test/java/chess/pieces/KnightTest.java
@@ -1,5 +1,6 @@
 package chess.pieces;
 
+import chess.board.Board;
 import chess.board.Position;
 import chess.pieces.color.Color;
 import org.junit.jupiter.api.DisplayName;
@@ -15,9 +16,11 @@ class KnightTest {
 	@Test
 	void givenKnight_whenFindMovablePositions_thenReturnsMovablePositions() {
 		// given
+		Board board = new Board();
+		board.initialize();
 		Knight knight = Knight.of(Color.BLACK);
 
-		Set<Position> positions = knight.movablePositions(new Position("c5"), Dummy.of());
+		Set<Position> positions = knight.movablePositions(new Position("c5"), Dummy.of(), board.getBoard());
 
 		assertThat(positions).containsExactlyInAnyOrder(
 				new Position("b7"), new Position("a6"),

--- a/src/test/java/chess/pieces/PawnTest.java
+++ b/src/test/java/chess/pieces/PawnTest.java
@@ -63,15 +63,15 @@ class PawnTest {
 		// given
 		Pawn pawn = Pawn.of(color);
 
-		Set<Position> positions = pawn.movablePositions(new Position("c7"));
+		Set<Position> positions = pawn.movablePositions(new Position("c7"), Dummy.of());
 
 		assertThat(positions).containsAll(expectedPosition);
 	}
 
 	private static Stream<Arguments> provideColorAndExpectedPositions() {
 		return Stream.of(
-				Arguments.of(Color.BLACK, Set.of(new Position("c6"), new Position("b6"), new Position("d6"))),
-				Arguments.of(Color.WHITE, Set.of(new Position("c8"), new Position("b8"), new Position("d8")))
+				Arguments.of(Color.BLACK, Set.of(new Position("c6"))),
+				Arguments.of(Color.WHITE, Set.of(new Position("c8")))
 		);
 	}
 }

--- a/src/test/java/chess/pieces/PawnTest.java
+++ b/src/test/java/chess/pieces/PawnTest.java
@@ -1,5 +1,6 @@
 package chess.pieces;
 
+import chess.board.Board;
 import chess.board.Position;
 import chess.pieces.color.Color;
 import org.assertj.core.api.SoftAssertions;
@@ -61,9 +62,11 @@ class PawnTest {
 	@ParameterizedTest
 	void givenPawn_whenFindMovablePositions_thenReturnsMovablePositions(Color color, Set<Position> expectedPosition) {
 		// given
+		Board board = new Board();
+		board.initialize();
 		Pawn pawn = Pawn.of(color);
 
-		Set<Position> positions = pawn.movablePositions(new Position("c7"), Dummy.of());
+		Set<Position> positions = pawn.movablePositions(new Position("c7"), Dummy.of(), board.getBoard());
 
 		assertThat(positions).containsAll(expectedPosition);
 	}

--- a/src/test/java/chess/pieces/QueenTest.java
+++ b/src/test/java/chess/pieces/QueenTest.java
@@ -17,7 +17,7 @@ class QueenTest {
 		// given
 		Queen queen = Queen.of(Color.BLACK);
 
-		Set<Position> positions = queen.movablePositions(new Position("c5"));
+		Set<Position> positions = queen.movablePositions(new Position("c5"), Dummy.of());
 
 		assertThat(positions).containsExactlyInAnyOrder(
 				new Position("b6"), new Position("a7"),

--- a/src/test/java/chess/pieces/QueenTest.java
+++ b/src/test/java/chess/pieces/QueenTest.java
@@ -1,5 +1,6 @@
 package chess.pieces;
 
+import chess.board.Board;
 import chess.board.Position;
 import chess.pieces.color.Color;
 import org.junit.jupiter.api.DisplayName;
@@ -15,19 +16,21 @@ class QueenTest {
 	@Test
 	void givenQueen_whenFindMovablePositions_thenReturnsMovablePositions() {
 		// given
+		Board board = new Board();
+		board.initialize();
 		Queen queen = Queen.of(Color.BLACK);
 
-		Set<Position> positions = queen.movablePositions(new Position("c5"), Dummy.of());
+		Set<Position> positions = queen.movablePositions(new Position("c5"), Dummy.of(), board.getBoard());
 
 		assertThat(positions).containsExactlyInAnyOrder(
-				new Position("b6"), new Position("a7"),
-				new Position("d6"), new Position("e7"), new Position("f8"),
+				new Position("b6"),
+				new Position("d6"),
 				new Position("b4"), new Position("a3"),
-				new Position("d4"), new Position("e3"), new Position("f2"), new Position("g1"),
-				new Position("c6"), new Position("c7"), new Position("c8"),
+				new Position("d4"), new Position("e3"),
+				new Position("c6"),
 				new Position("b5"), new Position("a5"),
 				new Position("d5"), new Position("e5"), new Position("f5"), new Position("g5"), new Position("h5"),
-				new Position("c4"), new Position("c3"), new Position("c2"), new Position("c1")
+				new Position("c4"), new Position("c3")
 		);
 	}
 

--- a/src/test/java/chess/pieces/RookTest.java
+++ b/src/test/java/chess/pieces/RookTest.java
@@ -1,5 +1,6 @@
 package chess.pieces;
 
+import chess.board.Board;
 import chess.board.Position;
 import chess.pieces.color.Color;
 import org.junit.jupiter.api.DisplayName;
@@ -15,15 +16,17 @@ class RookTest {
 	@Test
 	void givenRook_whenFindMovablePositions_thenReturnsMovablePositions() {
 		// given
+		Board board = new Board();
+		board.initialize();
 		Rook rook = Rook.of(Color.BLACK);
 
-		Set<Position> positions = rook.movablePositions(new Position("c5"), Dummy.of());
+		Set<Position> positions = rook.movablePositions(new Position("c5"), Dummy.of(), board.getBoard());
 
 		assertThat(positions).containsExactlyInAnyOrder(
-				new Position("c6"), new Position("c7"), new Position("c8"),
+				new Position("c6"),
 				new Position("b5"), new Position("a5"),
 				new Position("d5"), new Position("e5"), new Position("f5"), new Position("g5"), new Position("h5"),
-				new Position("c4"), new Position("c3"), new Position("c2"), new Position("c1")
+				new Position("c4"), new Position("c3")
 		);
 	}
 }

--- a/src/test/java/chess/pieces/RookTest.java
+++ b/src/test/java/chess/pieces/RookTest.java
@@ -17,7 +17,7 @@ class RookTest {
 		// given
 		Rook rook = Rook.of(Color.BLACK);
 
-		Set<Position> positions = rook.movablePositions(new Position("c5"));
+		Set<Position> positions = rook.movablePositions(new Position("c5"), Dummy.of());
 
 		assertThat(positions).containsExactlyInAnyOrder(
 				new Position("c6"), new Position("c7"), new Position("c8"),


### PR DESCRIPTION
## 구현 내용
- `Pawn`은 최초 이동 시 두 칸을 이동할 수 있도록 구현
- `Pawn`이 공격시에만 대각선으로 이동할 수 있도록 변경
- 턴에 따라 움직일 수 있도록 변경
- 기물이 이동할 때 말을 뛰어넘지 못하도록 변경